### PR TITLE
added bluetooth connection indicator

### DIFF
--- a/Network/bluetooth_connection.5s.sh
+++ b/Network/bluetooth_connection.5s.sh
@@ -1,0 +1,14 @@
+#!/bin/zsh
+
+# Note: requires blueutil
+# Install with `brew install blueutil`
+
+export PATH='/usr/local/bin:/usr/bin:$PATH'
+
+# Fixes missing Bluetooth connection status in macOS Big Sur
+if [[ $(blueutil --connected) == *", paired"* ]]
+then
+	echo 🔹BT
+else
+	echo N/A
+fi 


### PR DESCRIPTION
Requires blueutil installed.

This adds back a bluetooth connection indicator that was removed in macOS Big Sur (big shame).